### PR TITLE
Add driver comparison page and UI components

### DIFF
--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -1,0 +1,14 @@
+import DriverComparison from "@/components/DriverComparison";
+
+export const metadata = {
+  title: "Driver Comparison",
+};
+
+export default function ComparePage() {
+  return (
+    <main className="min-h-screen p-4">
+      <h1 className="text-2xl font-bold mb-4">Driver Comparison</h1>
+      <DriverComparison />
+    </main>
+  );
+}

--- a/src/components/DriverComparison.tsx
+++ b/src/components/DriverComparison.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import React, { useEffect, useState } from "react";
+import { Driver, getDrivers, getHeadToHead, HeadToHeadStats } from "@/lib/f1Api";
+import DriverSelect from "./DriverSelect";
+import HeadToHeadTable from "./HeadToHeadTable";
+
+export default function DriverComparison() {
+  const [season, setSeason] = useState("2023");
+  const [drivers, setDrivers] = useState<Driver[]>([]);
+  const [driver1, setDriver1] = useState("");
+  const [driver2, setDriver2] = useState("");
+  const [stats, setStats] = useState<HeadToHeadStats | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    getDrivers(season).then(setDrivers).catch(console.error);
+  }, [season]);
+
+  const compare = async () => {
+    if (!driver1 || !driver2) return;
+    setLoading(true);
+    try {
+      const s = await getHeadToHead(season, driver1, driver2);
+      setStats(s);
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const driver1Name = drivers.find((d) => d.driverId === driver1);
+  const driver2Name = drivers.find((d) => d.driverId === driver2);
+
+  return (
+    <div className="flex flex-col gap-4 max-w-md mx-auto p-4">
+      <label className="flex flex-col gap-1">
+        <span className="font-medium">Season</span>
+        <input
+          className="border rounded px-2 py-1 bg-background text-foreground"
+          value={season}
+          onChange={(e) => setSeason(e.target.value)}
+          placeholder="Season"
+        />
+      </label>
+
+      <DriverSelect
+        label="Driver 1"
+        drivers={drivers}
+        value={driver1}
+        onChange={setDriver1}
+      />
+      <DriverSelect
+        label="Driver 2"
+        drivers={drivers}
+        value={driver2}
+        onChange={setDriver2}
+      />
+      <button
+        className="border rounded px-4 py-2 bg-foreground text-background disabled:opacity-50"
+        onClick={compare}
+        disabled={!driver1 || !driver2 || loading}
+      >
+        {loading ? "Comparing..." : "Compare"}
+      </button>
+
+      {stats && driver1Name && driver2Name && (
+        <HeadToHeadTable
+          stats={stats}
+          driver1Name={`${driver1Name.givenName} ${driver1Name.familyName}`}
+          driver2Name={`${driver2Name.givenName} ${driver2Name.familyName}`}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/DriverSelect.tsx
+++ b/src/components/DriverSelect.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { Driver } from "@/lib/f1Api";
+
+interface DriverSelectProps {
+  label: string;
+  drivers: Driver[];
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export default function DriverSelect({ label, drivers, value, onChange }: DriverSelectProps) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="font-medium">{label}</span>
+      <select
+        className="border rounded px-2 py-1 bg-background text-foreground"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      >
+        <option value="">Select driver</option>
+        {drivers.map((d) => (
+          <option key={d.driverId} value={d.driverId}>
+            {d.givenName} {d.familyName}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/src/components/HeadToHeadTable.tsx
+++ b/src/components/HeadToHeadTable.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { HeadToHeadStats } from "@/lib/f1Api";
+
+interface Props {
+  stats: HeadToHeadStats | null;
+  driver1Name: string;
+  driver2Name: string;
+}
+
+export default function HeadToHeadTable({ stats, driver1Name, driver2Name }: Props) {
+  if (!stats) return null;
+  return (
+    <table className="border-collapse border mt-4 text-sm">
+      <thead>
+        <tr>
+          <th className="border px-2 py-1"></th>
+          <th className="border px-2 py-1 text-left">{driver1Name}</th>
+          <th className="border px-2 py-1 text-left">{driver2Name}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td className="border px-2 py-1 text-left">Wins</td>
+          <td className="border px-2 py-1 text-center">{stats.driver1Wins}</td>
+          <td className="border px-2 py-1 text-center">{stats.driver2Wins}</td>
+        </tr>
+        <tr>
+          <td className="border px-2 py-1 text-left">Ties</td>
+          <td className="border px-2 py-1 text-center" colSpan={2}>{stats.ties}</td>
+        </tr>
+      </tbody>
+    </table>
+  );
+}


### PR DESCRIPTION
## Summary
- create a comparison page to pick drivers and season
- add reusable `DriverSelect` and `HeadToHeadTable` components
- add `DriverComparison` client component for selecting drivers and viewing results

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6852a15123488329a5d6ef75d64f200a