### PR TITLE
Add cache and better error messages

### DIFF
--- a/src/components/DriverComparison.tsx
+++ b/src/components/DriverComparison.tsx
@@ -12,19 +12,25 @@ export default function DriverComparison() {
   const [driver2, setDriver2] = useState("");
   const [stats, setStats] = useState<HeadToHeadStats | null>(null);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    getDrivers(season).then(setDrivers).catch(console.error);
+    setError(null);
+    getDrivers(season)
+      .then(setDrivers)
+      .catch(() => setError("Failed to load drivers. Please try again."));
   }, [season]);
 
   const compare = async () => {
     if (!driver1 || !driver2) return;
     setLoading(true);
+    setError(null);
     try {
       const s = await getHeadToHead(season, driver1, driver2);
       setStats(s);
     } catch (e) {
       console.error(e);
+      setError("Failed to load race results. Please try again later.");
     } finally {
       setLoading(false);
     }
@@ -64,6 +70,8 @@ export default function DriverComparison() {
       >
         {loading ? "Comparing..." : "Compare"}
       </button>
+
+      {error && <p className="text-red-500">{error}</p>}
 
       {stats && driver1Name && driver2Name && (
         <HeadToHeadTable

--- a/src/lib/f1Api.ts
+++ b/src/lib/f1Api.ts
@@ -28,6 +28,10 @@ export interface HeadToHeadStats {
 
 const BASE_URL = "https://ergast.com/api/f1";
 
+// Simple in-memory caches keyed by season
+const driversCache: Record<string, Driver[]> = {};
+
+
 const driverSchema = z.object({
   driverId: z.string(),
   permanentNumber: z.string().optional(),
@@ -78,11 +82,16 @@ async function fetchJson<T>(url: string, schema: z.Schema<T>): Promise<T> {
 }
 
 export async function getDrivers(season: string): Promise<Driver[]> {
+  if (driversCache[season]) {
+    return driversCache[season];
+  }
   const data = await fetchJson(
     `${BASE_URL}/${season}/drivers.json?limit=1000`,
     driversResponseSchema
   );
-  return data.MRData.DriverTable.Drivers;
+  const drivers = data.MRData.DriverTable.Drivers;
+  driversCache[season] = drivers;
+  return drivers;
 }
 
 interface RaceResultInternal {
@@ -93,12 +102,19 @@ interface RaceResultInternal {
   Results: Array<{ position?: string; Driver: Driver }>;
 }
 
+const raceResultsCache: Record<string, RaceResultInternal[]> = {};
+
 export async function getRaceResults(season: string): Promise<RaceResultInternal[]> {
+  if (raceResultsCache[season]) {
+    return raceResultsCache[season];
+  }
   const data = await fetchJson(
     `${BASE_URL}/${season}/results.json?limit=1000`,
     racesResponseSchema
   );
-  return data.MRData.RaceTable.Races;
+  const races = data.MRData.RaceTable.Races;
+  raceResultsCache[season] = races;
+  return races;
 }
 
 function parsePosition(position?: string): number {


### PR DESCRIPTION
## Summary
- add simple in-memory caches for driver and race result API calls
- show friendly error messages on Driver Comparison page

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852a67f87d88329966560bcafab1d24